### PR TITLE
auto_profile_choice fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,18 @@ Usage: Select the resolution of the video.
     720p = "720" | "720p"
     240p = "240" | "240p"
 
+### auto_profile_choice
+Types: str
+
+Usage: Select which profile to use
+
+    Default = "" (forces you to chose manually)
+    "x" = your choice
+    if "x" = "0", this will do ALL profiles
+    if "x" is not equal to "0", this will scrape the respctive profile
+    
+    to get your profile number, run the scraper manually first.
+
 ### auto_site_choice:
 Types: str|int
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Usage: Select the resolution of the video.
 ### auto_profile_choice:
 Types: str
 
-Usage: Select which profile to use
+Usage: Automatically select which profile(s) to use
 
     Default = "" (forces you to chose manually)
     "x" = your choice

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Usage: Select the resolution of the video.
     720p = "720" | "720p"
     240p = "240" | "240p"
 
-### auto_profile_choice
+### auto_profile_choice:
 Types: str
 
 Usage: Select which profile to use

--- a/classes/make_settings.py
+++ b/classes/make_settings.py
@@ -140,7 +140,7 @@ class config(object):
                                 self.comments = option.get(
                                     'comments', True)
                         self.auto_profile_choice: Union[List] = option.get(
-                            'auto_profile_choice', [])
+                            'auto_profile_choice', "")
                         self.auto_model_choice = option.get(
                             'auto_model_choice', False)
                         self.auto_media_choice = option.get(


### PR DESCRIPTION
Got an error when I tried to set auto_profile_choice. Turns it was a TypeError as the value that was being passed was coming in as an int. When main_helper tried to figure out whether it was a digit, it would fail because int has no method named .isadigit().

This small change will pass the choice directly as a string, which will allow the scaper to function as normal.

Also updated README.md to tell people that this option exists, and how to use it with the new change. Hopefully my directions are clear enough that we don't get questions.

I did test this and the scrapper does not explode after this change.
