### PR TITLE
Fix Fansly media link picker

### DIFF
--- a/apis/fansly/classes/create_post.py
+++ b/apis/fansly/classes/create_post.py
@@ -11,7 +11,7 @@ class create_post:
         self.postedAtPrecise: str = option.get("postedAtPrecise")
         self.expiredAt: Any = option.get("expiredAt")
         self.author = create_user.create_user(extra["accounts"][0])
-        self.text: str = option.get("text")
+        self.text: str = option.get("content")
         self.rawText: str = option.get("rawText")
         self.lockedText: bool = option.get("lockedText")
         self.isFavorite: bool = option.get("isFavorite")
@@ -77,29 +77,47 @@ class create_post:
         self.isFavorite = True
         return results
 
-    async def link_picker(self, media: dict[Any, Any], video_quality: str):
-        link = ""
-        locations = media["locations"]
-        if locations:
-            link: str = locations[0]["location"]
-        # if "source" in media:
-        #     quality_key = "source"
-        #     source = media[quality_key]
-        #     link = source[quality_key]
-        #     if link:
-        #         if media["type"] == "video":
-        #             qualities = media["videoSources"]
-        #             qualities = dict(sorted(qualities.items(), reverse=False))
-        #             qualities[quality_key] = source[quality_key]
-        #             for quality, quality_link in qualities.items():
-        #                 video_quality = video_quality.removesuffix("p")
-        #                 if quality == video_quality:
-        #                     if quality_link:
-        #                         link = quality_link
-        #                         break
-        #                     print
-        #                 print
-        #             print
-        # if "src" in media:
-        #     link = media["src"]
-        return link
+    async def link_picker(self, media: dict[Any, Any], target_quality: str):
+        # There are two media results at play here.
+        # The top-level `media` element itself represents the original source quality.
+        # It may also contain a `variants` list entry with alternate encoding qualities.
+        # Each variant has a similar structure to the main media element.
+        source_media = media
+        variants = media.get("variants", [])
+
+        if target_quality == "source":
+            try:
+                return source_media["locations"][0]["location"]
+            except (KeyError, IndexError):
+                pass
+
+        # Track the target type as videos may also include thumbnail image variants.
+        target_type = source_media.get("mimetype")
+
+        qualities: list[Tuple[int, str]] = []
+        for variant in variants + [source_media]:
+            if variant.get("mimetype") != target_type:
+                continue
+
+            media_quality = variant["height"]
+            try:
+                media_url = variant["locations"][0]["location"]
+            except (KeyError, IndexError):
+                continue
+            qualities.append( (media_quality, media_url) )
+
+        if not qualities:
+            return
+
+        # Iterate the media from highest to lowest quality.
+        for media_quality, media_url in sorted(qualities, reverse=True):
+            # If there was no "source" quality media, return the highest quality/first media.
+            if target_quality == "source":
+                return media_url
+
+            # Return the first media <= the target quality.
+            if media_quality <= int(target_quality):
+                return media_url
+
+        # If all media was > target quality, return the lowest quality/last media.
+        return media_url


### PR DESCRIPTION
The main "locations" entry only exists if the media has a "source" quality.
If it doesn't, we have to check the "variants" entry list to find the closest quality.
Without this, posts that don't contain "source" quality media are skipped.