### PR TITLE
Open Settings In Editor

### DIFF
--- a/helpers/main_helper.py
+++ b/helpers/main_helper.py
@@ -11,6 +11,7 @@ import math
 import os
 import platform
 import random
+import subprocess
 import re
 import shutil
 import string
@@ -802,6 +803,15 @@ class download_session(tqdm):
         self.update(b)
 
 
+def prompt_modified(message, path):
+    editor = shutil.which(os.environ.get("EDITOR", "notepad" if os_name == "Windows" else "nano"))
+    if editor:
+        print(message)
+        subprocess.run([editor, path], check=True)
+    else:
+        input(message)
+
+
 def get_config(config_path):
     if os.path.exists(config_path):
         json_config = ujson.load(open(config_path))
@@ -819,9 +829,9 @@ def get_config(config_path):
         filepath = os.path.join(".settings", "config.json")
         export_data(json_config, filepath)
     if not json_config:
-        input(
-            f"The .settings\\{file_name} file has been created. Fill in whatever you need to fill in and then press enter when done.\n"
-        )
+        prompt_modified(
+            f"The .settings\\{file_name} file has been created. Fill in whatever you need to fill in and then press enter when done.\n",
+            config_path)
         json_config = ujson.load(open(config_path))
     return json_config, updated
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -21,8 +21,9 @@ def check_config():
     import helpers.main_helper as main_helper
     json_config, updated = main_helper.get_config(path)
     if updated:
-        input(
-            f"The .settings\\{file_name} file has been updated. Fill in whatever you need to fill in and then press enter when done.\n")
+        main_helper.prompt_modified(
+            f"The .settings\\{file_name} file has been updated. Fill in whatever you need to fill in and then press enter when done.\n",
+            path)
     return json_config
 
 
@@ -60,7 +61,8 @@ def check_profiles():
             else:
                 continue
             main_helper.export_data(new_item, auth_filepath)
-            string = f"{auth_filepath} has been created. Fill in the relevant details and then press enter to continue."
-            input(string)
+            main_helper.prompt_modified(
+                f"{auth_filepath} has been created. Fill in the relevant details and then press enter to continue.",
+                auth_filepath)
         print
     print


### PR DESCRIPTION
Discussed in #69, open every setting file that was changed in a text editor instead of having the user have to hunt for it.
(on Linux this defaults to `nano` instead of `vi` now, it's easier to use)