### PR TITLE
Fixes issue #56

### DIFF
--- a/apis/onlyfans/classes/create_auth.py
+++ b/apis/onlyfans/classes/create_auth.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from itertools import chain, product
 from multiprocessing.pool import Pool
 from typing import Any, Dict, List, Optional, Union
-from pprint import pprint
 
 import jsonpickle
 from apis import api_helper

--- a/apis/onlyfans/classes/create_auth.py
+++ b/apis/onlyfans/classes/create_auth.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from itertools import chain, product
 from multiprocessing.pool import Pool
 from typing import Any, Dict, List, Optional, Union
+from pprint import pprint
 
 import jsonpickle
 from apis import api_helper
@@ -429,7 +430,7 @@ class create_auth(create_user):
         self,
         check: bool = False,
         refresh: bool = True,
-        limit: int = 99,
+        limit: int = 10,
         offset: int = 0,
         inside_loop: bool = False,
     ) -> list[Union[create_message, create_post]]:
@@ -444,7 +445,7 @@ class create_auth(create_user):
         final_results = await self.session_manager.json_request(link)
         if not isinstance(final_results,error_details):
             if len(final_results) >= limit and not check:
-                results2 = self.get_paid_content(
+                results2 = await self.get_paid_content(
                     limit=limit, offset=limit + offset, inside_loop=True
                 )
                 final_results.extend(results2)

--- a/database/databases/user_data/alembic.ini
+++ b/database/databases/user_data/alembic.ini
@@ -74,7 +74,7 @@ handlers =
 qualname = sqlalchemy.engine
 
 [logger_alembic]
-level = INFO
+level = WARN
 handlers =
 qualname = alembic
 


### PR DESCRIPTION
Fixes #56

It appears that Onlyfans is only  returning the first 10 items of the purchased items. As a result the looping condition was never true (10 >= 100). By having the limit set back to 10 (as currently behaving on OF), we are able to parse all the paid contents.

Additionally:
- fixes a missing `await`.
- set the logger_alembic to WARN to avoid seeing all the INFO warnings.