### PR TITLE
Onlyfans blacklist also works directly on users in addition to remote lists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,16 +340,16 @@ Types: list|int|str|bool
 ### blacklist_name:
 
     Default = ""
+    Example = ["Blacklisted"]
+    Example = "Blacklisted,alsoforbidden"
 
-    This setting will not include any blacklisted usernames when you choose the "scrape all" option.
+    This setting allows you to remove usernames when you choose the "scrap all" option by using lists or targetting specific usernames.
 
-    Go to https://onlyfans.com/my/lists and create a new list; you can name it whatever you want but I called mine "Blacklisted".
-
+    1. Go to https://onlyfans.com/my/lists and create a new list; you can name it whatever you want but I called mine "Blacklisted".
     Add the list's name to the config.
-
     Example: "blacklist_name": "Blacklisted"
 
-    You can create as many lists as you want.
+    2. Or simply put the username of the content creator in the list.
 
 # FAQ
 

--- a/modules/onlyfans.py
+++ b/modules/onlyfans.py
@@ -1284,6 +1284,12 @@ async def manage_subscriptions(
                                 if identifier in bl_ids:
                                     print(f"Blacklisted: {identifier}")
                                     results.remove(result)
+        results2 = results.copy()
+        for result in results2:
+            identifier = result.username
+            if identifier in blacklists:
+                print(f"Blacklisted: {identifier}")
+                results.remove(result)
     results.sort(key=lambda x: x.subscribedByData["expiredAt"])
     results.sort(key=lambda x: x.is_me(), reverse=True)
     results2 = []


### PR DESCRIPTION
This also the double use of the setting `blacklists`:
-  Keep the original behavior from the remote lists,
-  but also allow the possibility to directly add usernames that the user would like to avoid.

I know there is the RTFM protocol.
This Pull Request mostly aims to fill the UX hole: "blacklist = direct filtering of the username".