### PR TITLE
.part File Cleanup

### DIFF
--- a/helpers/main_helper.py
+++ b/helpers/main_helper.py
@@ -1016,7 +1016,6 @@ def open_partial(path: str) -> BinaryIO:
         try:
             return open(partial_path, "xb")
         except FileExistsError:
-            os.unlink(partial_path)
             pass
 
 
@@ -1042,7 +1041,7 @@ async def write_data(response: ClientResponse, download_path: str, progress_bar)
                     ServerDisconnectedError,
                 ) as e:
                     status_code = 1
-        except Exception:
+        except:
             if partial_path:
                 os.unlink(partial_path)
             raise

--- a/helpers/main_helper.py
+++ b/helpers/main_helper.py
@@ -1049,7 +1049,10 @@ async def write_data(response: ClientResponse, download_path: str, progress_bar)
             if status_code:
                 os.unlink(partial_path)
             else:
-                os.replace(partial_path, download_path)
+                try:
+                    os.replace(partial_path, download_path)
+                except OSError:
+                    pass
     else:
         if response.content_length:
             progress_bar.update_total_size(-response.content_length)


### PR DESCRIPTION
This is to address leftover `.part` files when interrupting the script, discussed in https://github.com/DIGITALCRIMINALS/OnlyFans/commit/8d8e3cacd915f047de2e240631806c5188830332.

Also a quick fix to ignore errors while trying to move the `.part` file to its final location because apparently it happens (#113).