### PR TITLE
Undo Async Fix

### DIFF
--- a/helpers/main_helper.py
+++ b/helpers/main_helper.py
@@ -823,7 +823,8 @@ def prompt_modified(message, path):
 
 def get_config(config_path):
     if os.path.exists(config_path):
-        json_config = ujson.load(open(config_path))
+        with open(config_path, encoding="utf-8") as fp:
+            json_config = ujson.load(fp)
     else:
         json_config = {}
     json_config2 = copy.deepcopy(json_config)
@@ -842,7 +843,8 @@ def get_config(config_path):
             f"The .settings\\{file_name} file has been created. Fill in whatever you need to fill in and then press enter when done.\n",
             config_path,
         )
-        json_config = ujson.load(open(config_path))
+        with open(config_path, encoding="utf-8") as fp:
+            json_config = ujson.load(fp)
     return json_config, updated
 
 
@@ -934,7 +936,8 @@ def process_profiles(
             user_auth_filepath = os.path.join(user_profile, "auth.json")
             datas = {}
             if os.path.exists(user_auth_filepath):
-                temp_json_auth = ujson.load(open(user_auth_filepath))
+                with open(user_auth_filepath, encoding="utf-8") as fp:
+                    temp_json_auth = ujson.load(fp)
                 json_auth = temp_json_auth["auth"]
                 if not json_auth.get("active", None):
                     continue
@@ -1097,7 +1100,8 @@ def legacy_metadata(directory):
         if items:
             for item in items:
                 path = os.path.join(directory, item)
-                metadata = ujson.load(open(path))
+                with open(path, encoding="utf-8") as fp:
+                    metadata = ujson.load(fp)
                 metadatas.append(metadata)
                 print
         print

--- a/start_ofd.py
+++ b/start_ofd.py
@@ -101,9 +101,6 @@ try:
                     print("Pausing scraper for " + loop_timeout + " seconds.")
                     await asyncio.sleep(float(loop_timeout))
 
-        if sys.platform == "win32":
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
         asyncio.run(main())
 except Exception as e:
     print(traceback.format_exc())


### PR DESCRIPTION
Because the cure is worse than the disease (#107) - it's better to have a few harmless exceptions at exit than have the whole thing crash.

I have run the scraper with `python -X dev` and looked for `ResourceWarning`s, did not find anything related to sockets. It looks like all the HTTP connections are properly closed (even if the `response` objects are not explicitly closed or used with `async with`).

I found warnings with some `open` calls that I have fixed at the same time, and also corrected the text encoding which was incorrect (the default is `cp1252` on Windows).