### PR TITLE
Fix Dockerfile to use poetry install method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
-FROM python:3.10
+FROM python:3.10-slim
+
+RUN apt-get update && apt-get install -y \
+  curl \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app
 
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+ENV POETRY_HOME=/usr/local/share/pypoetry
+ENV POETRY_VIRTUALENVS_CREATE=false
+
+RUN ["/bin/bash", "-c", "set -o pipefail && curl -sSL https://install.python-poetry.org/install-poetry.py | python -"]
+
+COPY pyproject.toml poetry.lock ./
+RUN /usr/local/share/pypoetry/bin/poetry install
 
 COPY . .
 
-CMD [ "python", "./start_ofd.py" ]
+CMD [ "/usr/local/share/pypoetry/bin/poetry", "run", "python", "./start_ofd.py" ]


### PR DESCRIPTION
The current Dockerfile still tries to install using `requirements.txt` which was [removed](https://github.com/DIGITALCRIMINALS/OnlyFans/commit/551132b1deebd8d15f049acddaa38db138c88daf).

The changes in this PR fix it for me. I'm aware of other ways to do this (multi-stage builds and using `poetry build`) but my attempts to use them didn't work.

Closes #336 