### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ From the project folder open Windows Powershell/Terminal and run the commands be
 
 Start:
 
->`python start_ofd.py` | `python3 start_ofd.py` | `python3.10 start_ofd.py` | double click `start_ofd.py`
+>`python start_ofd.py` | `python3 start_ofd.py` | `python3.10 start_ofd.py` | double click `start_ofd.py | poetry run python ./start_ofd.py`
 >
 > If you're experimenting auth loops, stuck downloads, run the program with `python -v start_ofd.py` and you may see which errors you're getting.
 ---
@@ -36,7 +36,7 @@ You have to fill in the following:
 - `{"x_bc":"x-bc_value"}`
 - `{"user_agent":"user-agent_value"}`
 
-Go to www.onlyfans.com and login, open the network debugger, then check the image below on how to get said above auth values
+Go to www.onlyfans.com and login, open the network debugger, then check the image below on how to get said above auth values. Using Chrome for this process is recommended, as other browsers sometimes have issues producing values that will auth properly.
 
 ![app-token](docs/assets/img/3.png)
 ![app-token](docs/assets/img/4.png)
@@ -53,7 +53,7 @@ Note: If active is set to False, the script will ignore the profile.
 
 # USAGE
 
-`python start_ofd.py` | `python3 start_ofd.py` | double click `start_ofd.py`
+`python start_ofd.py` | `python3 start_ofd.py` | `poetry run python ./start_ofd.py` | double click `start_ofd.py`
 
 Enter in inputs as prompted by console.
 


### PR DESCRIPTION
I've added some information that I've discovered along the way of using the OF scraper in particular.

When attempting to auth with values pulled from Firefox, access is denied and it will kill the current session. Sometimes users open issues for this (see #325, #277). This might be some way that I have FF configured, with containers and tracking protection etc, but whatever the root cause FF consistently doesn't work when Chrome does.

I've run into this two or three times now and each time I forget it only worked after I used auth values pulled from Chrome, since the credentials last quite some time. I think at the least this will help keep folks who can read from opening needless issues. And lastly, the standard "RTFM" response used around here will be hardened.

Also another `poetry run` command, since the requirements file has been removed and I was getting import errors (same as #335).