### PR TITLE
[Fansly] Semi-fix message scraping (and use API V3)

### DIFF
--- a/apis/api_helper.py
+++ b/apis/api_helper.py
@@ -339,7 +339,7 @@ class session_manager:
                 )
             headers2 = self.create_signed_headers(link)
             headers |= headers2
-        elif "https://apiv2.fansly.com" in link and isinstance(
+        elif "https://apiv3.fansly.com" in link and isinstance(
             self.auth.auth_details, fansly_extras.auth_details
         ):
             headers["authorization"] = self.auth.auth_details.authorization

--- a/apis/fansly/classes/extras.py
+++ b/apis/fansly/classes/extras.py
@@ -109,8 +109,9 @@ class endpoint_links(object):
         global_limit: int = 10,
         global_offset: int = 0,
         sort_order: Literal["asc", "desc"] = "desc",
+        before_id: str = ""
     ):
-        domain = "https://apiv2.fansly.com"
+        domain = "https://apiv3.fansly.com"
         api = "/api/v1"
         full_url_path = f"{domain}{api}"
         self.full_url_path = full_url_path
@@ -126,7 +127,7 @@ class endpoint_links(object):
         self.message_by_id = f"https://onlyfans.com/api2/v2/chats/{identifier}/messages?limit=10&offset=0&firstId={identifier2}&order=desc&skip_users=all&skip_users_dups=1"
         self.search_chat = f"https://onlyfans.com/api2/v2/chats/{identifier}/messages/search?query={text}"
         self.groups_api = f"{full_url_path}/group"
-        self.message_api = f"{full_url_path}/message?groupId={identifier}&limit={global_limit}&offset={global_offset}&order=desc"
+        self.message_api = f"{full_url_path}/message?groupId={identifier}&limit={global_limit}&before={before_id}&order=desc"
         self.search_messages = f"https://onlyfans.com/api2/v2/chats/{identifier}?limit=10&offset=0&filter=&order=activity&query={text}"
         self.mass_messages_api = f"https://onlyfans.com/api2/v2/messages/queue/stats?limit=100&offset=0&format=infinite"
         self.stories_api = f"https://onlyfans.com/api2/v2/users/{identifier}/stories?limit=100&offset=0&order=desc"

--- a/apis/fansly/classes/user_model.py
+++ b/apis/fansly/classes/user_model.py
@@ -358,8 +358,8 @@ class create_user:
     async def get_messages(
         self,
         links: Optional[list[str]] = None,
-        limit: int = 10,
-        offset: int = 0,
+        limit: int = 100000,
+        before: str = "",
         refresh: bool = True,
         inside_loop: bool = False,
     ) -> list[Any]:
@@ -381,19 +381,12 @@ class create_user:
         if found_id:
             if links is None:
                 links = []
-            multiplier = self.get_session_manager().max_threads
-            if links:
-                link = links[-1]
-            else:
-                link = endpoint_links(
-                    identifier=found_id, global_limit=limit, global_offset=offset
-                ).message_api
-                links.append(link)
-            links2 = api_helper.calculate_the_unpredictable(link, limit, multiplier)
-            if not inside_loop:
-                links += links2
-            else:
-                links = links2
+
+            link = endpoint_links(
+                identifier=found_id, global_limit=limit, before_id=before
+            ).message_api
+            links.append(link)
+
             results = await self.get_session_manager().async_requests(links)
             results = await api_helper.remove_errors(results)
             results = api_helper.merge_dictionaries(results)
@@ -403,10 +396,11 @@ class create_user:
             final_results = extras["messages"]
 
             if final_results:
+                lastId = final_results[-1]["id"]
                 results2 = await self.get_messages(
                     links=[links[-1]],
                     limit=limit,
-                    offset=limit + offset,
+                    before=lastId,
                     inside_loop=True,
                 )
                 final_results.extend(results2)


### PR DESCRIPTION
This somewhat fixes message scraping and also makes the scraper use Fansly's API V3.

There are minimal differences between V2 and V3 from what I could tell, besides the fact that offsets aren't used for messages anymore and instead it uses `before` cursors(?) - `before={ID-Of-Earliest-Message-In-Current-Batch}`

I call this a "semi-fix", as it seems to work as intended, but there's at least one issue: 
Recursive scraping (by calling `get_messages()` recursively) doesn't seem to work as intended. My workaround for it was to set `limit=100000` and from my testing that works.
However, I don't know if Fansly just silently accepts that limit and then sets a certain maximum internally. The maximum messages I was able to retrieve with a creator was 187 (that's how many messages total between me & the creator), so there might be a "hidden limit" of 200 or something.

Paid content is still being put in the "free" folder (reported in #394), as I didn't look into that. My main focus was to get message scraping mostly working again.

Fixes #507 