### PR TITLE
Only check requested accounts in Messages api parsing

### DIFF
--- a/helpers/main_helper.py
+++ b/helpers/main_helper.py
@@ -1038,14 +1038,16 @@ async def process_jobs(
             chats = await authed.get_chats()
             for chat in chats:
                 username: str = chat["withUser"].username
-                subscription = await authed.get_subscription(identifier=username)
-                if not subscription:
-                    subscription = chat["withUser"]
-                    authed.subscriptions.append(subscription)
-                    subscription.create_directory_manager()
-                await datascraper.start_datascraper(
-                    authed, username, whitelist=["Messages"]
-                )
+                for subscription in subscription_list:
+                    if username == subscription.username:
+                        subscription = await authed.get_subscription(identifier=username)
+                        if not subscription:
+                            subscription = chat["withUser"]
+                            authed.subscriptions.append(subscription)
+                            subscription.create_directory_manager()
+                        await datascraper.start_datascraper(
+                            authed, username, whitelist=["Messages"]
+                        )
             print
     if not subscription_list:
         print("There's no subscriptions to scrape.")


### PR DESCRIPTION
This change goal is to only check for the requested accounts during the Messages api check instead of parsing each of the followed accounts.